### PR TITLE
always_run is deprecated, replaced with check_mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: "[mdadm-bad-blocks] Check if mdadm supports bbl="
   command: grep bbl=no /sbin/mdadm
   register: has_bbl
-  always_run: true
+  check_mode: true
   failed_when: false
   changed_when: false
 


### PR DESCRIPTION
Need to use `check_mode: false` now to make this always run during check.