### PR TITLE
check_mode should be "false"; logic reversed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: "[mdadm-bad-blocks] Check if mdadm supports bbl="
   command: grep bbl=no /sbin/mdadm
   register: has_bbl
-  check_mode: true
+  check_mode: false
   failed_when: false
   changed_when: false
 


### PR DESCRIPTION
Sorry, the logic with check_mode is reversed compared to always_run, so it should be "false".

See
https://medium.com/opsops/understanding-ansibles-check-mode-299fd8a6a532
for more info.

        check_mode: false, it cause task to run even in --check mode.